### PR TITLE
adding HAS_OLED to build vars to guard in place of using OLED_SDA

### DIFF
--- a/firmware/config.h
+++ b/firmware/config.h
@@ -56,17 +56,17 @@
 #endif
 
 #ifdef HELTEC
-#define LORA_IRQ DIO0
-#define LORA_IO1 DIO1
-#define LORA_IO2 DIO2
-#define LORA_SCK SCK
-#define LORA_MISO MISO
-#define LORA_MOSI MOSI
-#define LORA_RST RST_LoRa
-#define LORA_CS SS
-//#define OLED_SDA SDA_OLED
-#define OLED_SCL SCL_OLED
-#define OLED_RST RST_OLED
+#define LORA_IRQ 26
+#define LORA_IO1 35
+#define LORA_IO2 34
+#define LORA_SCK 5
+#define LORA_MISO 19
+#define LORA_MOSI 27
+#define LORA_RST 14
+#define LORA_CS 18
+#define OLED_SDA 4
+#define OLED_SCL 15
+#define OLED_RST 16
 #define OLED_WIDTH 128
 #define OLED_HEIGHT 64
 #endif

--- a/firmware/main.ino
+++ b/firmware/main.ino
@@ -11,8 +11,9 @@
 #include <AsyncSDServer.h>
 #include <SD.h>
 #include <SPIFFS.h>
-#include "SSD1306Wire.h"
-
+#ifdef HAS_OLED
+#include <SSD1306Wire.h>
+#endif
 #include "config.h"
 
 // server
@@ -43,7 +44,7 @@
 
 #define INDEX_FILE "index.htm"
 
-#ifdef OLED_SDA
+#ifdef HAS_OLED
 SSD1306Wire display(0x3c, OLED_SDA, OLED_SCL);
 #endif
 
@@ -337,7 +338,7 @@ void setupLoRa()
 
 void drawStatusBar()
 {
-  #ifdef OLED_SDA
+  #ifdef HAS_OLED
   if (!displayInitialized)
   {
     return;
@@ -385,7 +386,7 @@ void drawStatusBar()
 
 void setupDisplay()
 {
-#ifdef OLED_SDA
+#ifdef HAS_OLED
   Serial.println("* Initializing display...");
   if (OLED_RST != NOT_A_PIN)
   {

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -57,6 +57,7 @@ build_flags = -DTTGO_TBEAM
 [env:heltec-v2]
 board = heltec_wifi_lora_32_V2
 build_flags = -DHELTEC
+              -DHAS_OLED
               -I./src
 
 [env:sparkfun-lora]

--- a/firmware/src/client/OLEDClient.cpp
+++ b/firmware/src/client/OLEDClient.cpp
@@ -1,7 +1,7 @@
 
 #include "OLEDClient.h"
 
-#ifdef OLED_SDA
+#ifdef HAS_OLED
 #define LINE_HEIGHT 10
 
 OLEDClient::~OLEDClient() {}

--- a/firmware/src/client/OLEDClient.h
+++ b/firmware/src/client/OLEDClient.h
@@ -5,7 +5,7 @@
 #include "../DisasterClient.h"
 #include "../DisasterServer.h"
 
-#ifdef OLED_SDA
+#ifdef HAS_OLED
 #include "SSD1306Wire.h"
 #include <list>
 


### PR DESCRIPTION
This PR needs to be rebased against master before merging to master.  It's meant to illustrate what I mentioned in #74, and based on the commit mentioned there.

Illustrating adding a build var to condition on for including OLED specifics.