### PR TITLE
Improve Wifi client mode

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -3,6 +3,19 @@ This firmware interfaces with the LoRa transciever and Javascript web apps.
 # Setup and development
 See the main [README](https://github.com/sudomesh/disaster-radio) to build the firmware
 
+## Connect to existing WiFi
+
+In WiFi mode, the firmware by default creates it's own SSID. If you want to connect to your own Wifi instead, 
+copy the file `secrets.H` to `secrets.h` and modify the file accordingly
+
+    /* Place SSIDs, Passwords, Hashes, etc. in this file, it will not be tracked by git */
+    
+    // Uncomment to enable the Wifi client
+    // #define WIFI_SSID "WIFI_SSID"
+    // #define WIFI_PASSWORD "WIFI_PASSWORD"
+
+Then follow the build instruction in the main [README](https://github.com/sudomesh/disaster-radio)
+
 # Testing
 Debugging can be done over serial using a tty interface, such as screen or minicom.
 To test the web app:  

--- a/firmware/main.ino
+++ b/firmware/main.ino
@@ -91,7 +91,7 @@ int clients = 0;
 int routes = 0;
 
 #define WIFI_POLL_DELAY 500
-#define WIFI_POLL_TRIES 10
+#define WIFI_POLL_TRIES 20
 
 char nodeAddress[ADDR_LENGTH*2 + 1] = {'\0'};
 char ssid[100] = {'\0'};
@@ -115,9 +115,9 @@ void setupWiFi()
 
 #ifdef WIFI_SSID
   Serial.printf(" --> Connecting to WiFi \"%s\"\n", WIFI_SSID);
-  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
   for (int i = 0; i < WIFI_POLL_TRIES && WiFi.status() != WL_CONNECTED; i++)
   {
+    WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
     delay(WIFI_POLL_DELAY);
   }
   if (WiFi.status() == WL_CONNECTED)
@@ -148,6 +148,14 @@ void setupWiFi()
     Serial.printf(" --> Started WiFi AP \"%s\", IP address: ", ssid);
     Serial.println(ip);
   }
+}
+
+void checkWiFi() {
+#ifdef WIFI_SSID
+  if (WiFi.status() != WL_CONNECTED) {
+    WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+  }
+#endif
 }
 
 void setupMDNS()
@@ -562,4 +570,10 @@ void loop()
       drawStatusBar();
     }
   }
+  // reconnect only in WiFi client mode 
+#ifdef WIFI_SSID
+  if (!useBLE) {
+    checkWiFi();
+  }
+#endif
 }

--- a/firmware/secrets.H
+++ b/firmware/secrets.H
@@ -1,0 +1,7 @@
+/* 
+ * Copy this file to 'secrets.h' and place SSIDs, passwords etc in that file,
+ * it will not be tracked by git
+ */
+
+//#define WIFI_SSID "WIFI_SSID"
+//#define WIFI_PASSWORD "WIFI_PASSWORD"


### PR DESCRIPTION
This commit makes connecting to an existing WiFi more robust and adds the missing `secrets.h` file for WiFi configuration.

It fixes issue #98 and restores the `secrets.h` template from an an [old commit](https://github.com/sudomesh/disaster-radio/blob/d0f8319c65a614a6425ec29401cd43f7e6818a5b/firmware/esp32/secrets.h). It also adds a section to the `README.md` in firmware, so that it's documented on how to integrate their disaster radio node into their existing Wifi network