### PR TITLE
Esp32v3 initial support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,8 @@ web/node_modules
 makeEspArduino/
 lib/**
 firmware/lib/**
-
+hardware/board_esp32_v3/**
+firmware/platformio.ini
 .pio
 .vscode
 secrets.h

--- a/firmware/config.h
+++ b/firmware/config.h
@@ -99,24 +99,25 @@
 #endif
 
 #ifdef ESP32_V3
-#define LORA_IRQ 36
-#define LORA_CS 27
-#define LORA_IO1 11
+
+#define LORA_IRQ 22
+#define LORA_CS 16
+#define LORA_IO1 26
 #define LORA_IO2 NOT_A_PIN
-#define LORA_RST 15
-#define LORA_SCK 30
-#define LORA_MOSI 37
-#define LORA_MISO 31
-#define LORA_RXEN 28
+#define LORA_RST NOT_A_PIN
+#define LORA_SCK 18
+#define LORA_MOSI 23
+#define LORA_MISO 19
+#define LORA_RXEN 17
 
 //comment all LORA2 lines and -DDUAL_LORA build flag to disable second module
 
-#define LORA2_CS 9
-#define LORA2_IRQ 7
-#define LORA2_RST 15
-#define LORA2_IO1 12
+#define LORA2_CS 33
+#define LORA2_IRQ 35
+#define LORA2_RST NOT_A_PIN
+#define LORA2_IO1 27
 #define LORA2_IO2 NOT_A_PIN
-#define LORA2_RXEN 33
+#define LORA2_RXEN 21
 #endif
 
 #endif

--- a/firmware/config.h
+++ b/firmware/config.h
@@ -98,4 +98,24 @@
 #define LORA2_CS 25
 #endif
 
+#ifdef ESP32_V3
+#define LORA_IRQ 36
+#define LORA_CS 27
+#define LORA_IO1 11
+#define LORA_IO2 NOT_A_PIN
+#define LORA_RST 15
+#define LORA_SCK 30
+#define LORA_MOSI 37
+#define LORA_MISO 31
+#define LORA_RXEN 28
+
+#define DUAL_LORA
+
+#define LORA2_CS 9
+#define LORA2_IRQ 7
+#define LORA2_RST 15
+#define LORA2_IO1 12
+#define LORA2_IO2 NOT_A_PIN
+#define LORA2_RXEN 33
+
 #endif

--- a/firmware/config.h
+++ b/firmware/config.h
@@ -109,7 +109,7 @@
 #define LORA_MISO 31
 #define LORA_RXEN 28
 
-#define DUAL_LORA
+//comment all LORA2 lines and -DDUAL_LORA build flag to disable second module
 
 #define LORA2_CS 9
 #define LORA2_IRQ 7
@@ -117,5 +117,6 @@
 #define LORA2_IO1 12
 #define LORA2_IO2 NOT_A_PIN
 #define LORA2_RXEN 33
+#endif
 
 #endif

--- a/firmware/main.ino
+++ b/firmware/main.ino
@@ -1,5 +1,5 @@
 #include <Arduino.h>
-
+#define RL_SX1262
 // required for LoRa and/or AsyncSDServer libraries?
 #include <FS.h>
 #include <SPI.h>
@@ -15,16 +15,17 @@
 #include <SSD1306Wire.h>
 #endif
 #include "config.h"
-
+/*
 #ifdef ARDUINO_LORA
 #include <Layer1_LoRa.h>
 #endif
-
+*/
 #ifdef RL_SX1276
 #include <Layer1_SX1276.h>
 #endif
 #ifdef RL_SX1262
 #include <Layer1_SX126x.h>
+#undef ARDUINO_LORA
 #endif
 
 #include <LoRaLayer2.h>
@@ -71,11 +72,11 @@ AsyncWebServer http_server(80);
 AsyncWebSocket ws_server("/ws");
 
 BleUartClient ble_client;
-
+/*
 #ifdef ARDUINO_LORA
 Layer1Class *Layer1 = new Layer1Class();
 #endif
-
+*/
 #ifdef RL_SX1276
 SX1276 lora = new Module(LORA_CS, LORA_IRQ, LORA_RST, RADIOLIB_NC);
   #ifdef DUAL_LORA
@@ -359,6 +360,7 @@ void setupLoRa()
   #ifdef LOPY4
   SPI.begin(LORA_SCK, LORA_MISO, LORA_MOSI); //LORA_CS);
   #endif
+  /*
   #ifdef ARDUINO_LORA
   Layer1Class *Layer1_1 = new Layer1Class();
   Layer1_1->setPins(LORA_CS, LORA_RST, LORA_IRQ);
@@ -366,6 +368,7 @@ void setupLoRa()
   Layer1_1->setTxPower(txPower);
   Layer1_1->setSpreadingFactor(spreadingFactor);
   #endif
+  */
   #if defined ( RL_SX1276 ) || defined ( RL_SX1262 )
   pinMode(LORA_CS, OUTPUT);
   digitalWrite(LORA_CS, LOW);

--- a/firmware/main.ino
+++ b/firmware/main.ino
@@ -23,6 +23,9 @@
 #ifdef RL_SX1276
 #include <Layer1_SX1276.h>
 #endif
+#ifdef RL_SX1262
+#include <Layer1_SX126x.h>
+#endif
 
 #include <LoRaLayer2.h>
 
@@ -76,6 +79,13 @@ Layer1Class *Layer1 = new Layer1Class();
 SX1276 lora = new Module(LORA_CS, LORA_IRQ, LORA_RST, RADIOLIB_NC);
   #ifdef DUAL_LORA
   SX1276 lora2 = new Module(LORA2_CS, LORA2_IRQ, LORA2_RST, RADIOLIB_NC);
+  #endif
+#endif
+
+#ifdef RL_SX1262
+SX1262 lora = new Module(LORA_CS, LORA_IRQ, LORA_RST, RADIOLIB_NC);
+  #ifdef DUAL_LORA
+  SX1262 lora2 = new Module(LORA2_CS, LORA2_IRQ, LORA2_RST, RADIOLIB_NC);
   #endif
 #endif
 
@@ -355,7 +365,7 @@ void setupLoRa()
   Layer1_1->setTxPower(txPower);
   Layer1_1->setSpreadingFactor(spreadingFactor);
   #endif
-  #ifdef RL_SX1276
+  #ifdef RL_SX1262
   pinMode(LORA_CS, OUTPUT);
   digitalWrite(LORA_CS, LOW);
   #ifdef DUAL_LORA
@@ -366,7 +376,7 @@ void setupLoRa()
   #ifdef DUAL_LORA
   digitalWrite(LORA_CS, HIGH);
   digitalWrite(LORA2_CS, LOW);
-  Layer1Class *Layer1_2 = new Layer1Class(&lora2, 0, LORA2_CS, LORA2_RST, LORA2_IRQ, 7, 433, 17);
+  Layer1Class *Layer1_2 = new Layer1Class(&lora2, 0, LORA2_CS, LORA2_RST, LORA2_IRQ, 7, 915, 17);
   digitalWrite(LORA_CS, LOW);
   digitalWrite(LORA2_CS, HIGH);
   #endif

--- a/firmware/main.ino
+++ b/firmware/main.ino
@@ -75,6 +75,7 @@ BleUartClient ble_client;
 #ifdef ARDUINO_LORA
 Layer1Class *Layer1 = new Layer1Class();
 #endif
+
 #ifdef RL_SX1276
 SX1276 lora = new Module(LORA_CS, LORA_IRQ, LORA_RST, RADIOLIB_NC);
   #ifdef DUAL_LORA
@@ -365,7 +366,7 @@ void setupLoRa()
   Layer1_1->setTxPower(txPower);
   Layer1_1->setSpreadingFactor(spreadingFactor);
   #endif
-  #ifdef RL_SX1262
+  #if defined ( RL_SX1276 ) || defined ( RL_SX1262 )
   pinMode(LORA_CS, OUTPUT);
   digitalWrite(LORA_CS, LOW);
   #ifdef DUAL_LORA

--- a/firmware/main.ino
+++ b/firmware/main.ino
@@ -1,5 +1,5 @@
 #include <Arduino.h>
-#define RL_SX1262
+
 // required for LoRa and/or AsyncSDServer libraries?
 #include <FS.h>
 #include <SPI.h>
@@ -15,17 +15,16 @@
 #include <SSD1306Wire.h>
 #endif
 #include "config.h"
-/*
+
 #ifdef ARDUINO_LORA
 #include <Layer1_LoRa.h>
 #endif
-*/
+
 #ifdef RL_SX1276
 #include <Layer1_SX1276.h>
 #endif
 #ifdef RL_SX1262
 #include <Layer1_SX126x.h>
-#undef ARDUINO_LORA
 #endif
 
 #include <LoRaLayer2.h>
@@ -72,11 +71,11 @@ AsyncWebServer http_server(80);
 AsyncWebSocket ws_server("/ws");
 
 BleUartClient ble_client;
-/*
+
 #ifdef ARDUINO_LORA
 Layer1Class *Layer1 = new Layer1Class();
 #endif
-*/
+
 #ifdef RL_SX1276
 SX1276 lora = new Module(LORA_CS, LORA_IRQ, LORA_RST, RADIOLIB_NC);
   #ifdef DUAL_LORA
@@ -360,15 +359,15 @@ void setupLoRa()
   #ifdef LOPY4
   SPI.begin(LORA_SCK, LORA_MISO, LORA_MOSI); //LORA_CS);
   #endif
-  /*
-  #ifdef ARDUINO_LORA
+  
+  #if defined (ARDUINO_LORA)
   Layer1Class *Layer1_1 = new Layer1Class();
   Layer1_1->setPins(LORA_CS, LORA_RST, LORA_IRQ);
   Layer1_1->setLoRaFrequency(loraFrq*1E6);
   Layer1_1->setTxPower(txPower);
   Layer1_1->setSpreadingFactor(spreadingFactor);
   #endif
-  */
+  
   #if defined ( RL_SX1276 ) || defined ( RL_SX1262 )
   pinMode(LORA_CS, OUTPUT);
   digitalWrite(LORA_CS, LOW);

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -17,7 +17,8 @@ default_envs=
     ;ttgo-lora32-tbeam
     ;heltec-v2
     ;sparkfun-lora
-    ;lopy4
+    ; lopy4
+    ; esp32-v3
 
 [env]
 platform = https://github.com/platformio/platform-espressif32.git
@@ -92,3 +93,9 @@ build_flags = -DLOPY4
               -I./src
             ; -DDUAL_LORA
             ; -DLL2_DEBUG
+[env:esp32-v3]
+board = esp32-v3
+build_flags = -DESP32_V3
+		  -DRL_SX1276
+	      -I./src
+	      -DDUAL_LORA

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -13,7 +13,7 @@ src_dir = .
 data_dir = ../web/static
 default_envs= 
     ;ttgo-lora32-v1
-    ttgo-lora32-v2
+     ttgo-lora32-v2
     ;ttgo-lora32-tbeam
     ;heltec-v2
     ;sparkfun-lora
@@ -94,8 +94,9 @@ build_flags = -DLOPY4
             ; -DDUAL_LORA
             ; -DLL2_DEBUG
 [env:esp32-v3]
-board = esp32-v3
+board = esp32dev
+board_upload.maximum_ram_size = 532480
 build_flags = -DESP32_V3
-		  -DRL_SX1276
+	      -DRL_SX1276
 	      -I./src
 	      -DDUAL_LORA

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -13,12 +13,12 @@ src_dir = .
 data_dir = ../web/static
 default_envs= 
     ;ttgo-lora32-v1
-     ttgo-lora32-v2
+    ;ttgo-lora32-v2
     ;ttgo-lora32-tbeam
     ;heltec-v2
     ;sparkfun-lora
     ; lopy4
-    ; esp32-v3
+     esp32-v3
 
 [env]
 platform = https://github.com/platformio/platform-espressif32.git
@@ -35,7 +35,7 @@ lib_deps =
     ESP Async WebServer@1.2.3
     LoRa@0.7.2
     https://github.com/jgromes/RadioLib#3682c6c9215891e3afb7672f1235fde1c3bd75fd
-    https://github.com/sudomesh/LoRaLayer2#efaa3fa73e3c8f6a7c66e335873c0bd81cc865e3
+    https://github.com/code8buster/LoRaLayer2.git#esp32v3
     https://github.com/paidforby/AsyncSDServer#13375c6be978cb34180378ecf4042a3a4a1f5eab
     ESP8266 and ESP32 OLED driver for SSD1306 displays
     TinyGPSPlus@1.0.2
@@ -95,8 +95,9 @@ build_flags = -DLOPY4
             ; -DLL2_DEBUG
 [env:esp32-v3]
 board = esp32dev
+board_upload.maximum_size = 4194304
 board_upload.maximum_ram_size = 532480
 build_flags = -DESP32_V3
-	      -DRL_SX1276
+	      -DRL_SX1262
 	      -I./src
 	      -DDUAL_LORA


### PR DESCRIPTION
Please ensure platformio.ini does not point to my personal repository for LoRaLayer2. I don't know how that got wrapped up in there, and I'm not practiced with git.

esp32-v3 hardware still does not initialize the radios with these modifications but at the least, it instantiates the Layer 1 wrapper for the Ebyte SX1262 modules correctly without error.

All commits including my rookie mistakes!